### PR TITLE
Add Kultusministerium and schools

### DIFF
--- a/froide/local_settings.py.example
+++ b/froide/local_settings.py.example
@@ -16,6 +16,12 @@ class Dev(Base):
     # SITE_EMAIL = 'info@example.com'
     # SITE_URL = 'http://localhost:8000'
     # SITE_ID = 1
+    # Only allow these public bodies to be selectable
+    # SELECTABLE_PUBLICBODY_SLUGS = [
+    #     "kultusministerium",
+    #     "schule-1",
+    #     "schule-2",
+    # ]
 
     # ADMINS = (
     #     # ('Your Name', 'your_email@example.com'),

--- a/froide/publicbody/forms.py
+++ b/froide/publicbody/forms.py
@@ -31,6 +31,12 @@ class PublicBodyForm(JSONMixin, forms.Form):
         label=_("Search for a topic or a public body:"),
     )
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        allowed = getattr(settings, "SELECTABLE_PUBLICBODY_SLUGS", None)
+        if allowed:
+            self.fields["publicbody"].queryset = PublicBody.objects.filter(slug__in=allowed)
+
     is_multi = False
 
     def as_data(self):
@@ -58,6 +64,19 @@ class MultiplePublicBodyForm(PublicBodyForm):
     )
 
     is_multi = True
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        allowed = getattr(settings, "SELECTABLE_PUBLICBODY_SLUGS", None)
+        if allowed:
+            self.fields["publicbody"].queryset = (
+                PublicBody.objects.filter(slug__in=allowed).prefetch_related(
+                    "classification",
+                    "jurisdiction",
+                    "categories",
+                    "laws",
+                )
+            )
 
     def get_publicbodies(self):
         if self.is_valid():

--- a/froide/publicbody/migrations/0051_add_kultus_school_publicbodies.py
+++ b/froide/publicbody/migrations/0051_add_kultus_school_publicbodies.py
@@ -1,0 +1,78 @@
+from django.db import migrations
+
+
+def create_kultus_school_pbs(apps, schema_editor):
+    Jurisdiction = apps.get_model("publicbody", "Jurisdiction")
+    FoiLaw = apps.get_model("publicbody", "FoiLaw")
+    PublicBody = apps.get_model("publicbody", "PublicBody")
+    Site = apps.get_model("sites", "Site")
+
+    site = Site.objects.get(pk=1)
+
+    jur, _ = Jurisdiction.objects.get_or_create(
+        slug="edu",
+        defaults={
+            "name": "Education Jurisdiction",
+            "description": "",
+            "rank": 1,
+            "hidden": False,
+        },
+    )
+
+    law, _ = FoiLaw.objects.get_or_create(
+        slug="dsgvo",
+        defaults={
+            "name": "Datenschutz-Grundverordnung",
+            "jurisdiction": jur,
+            "priority": 1,
+            "site": site,
+        },
+    )
+
+    km, _ = PublicBody.objects.get_or_create(
+        slug="kultusministerium",
+        defaults={
+            "name": "Kultusministerium",
+            "email": "poststelle@kultus.example.com",
+            "url": "https://www.kultus.example.com",
+            "jurisdiction": jur,
+            "site": site,
+        },
+    )
+    km.laws.add(law)
+
+    for slug, name in [
+        ("schule-1", "Muster-Schule 1"),
+        ("schule-2", "Muster-Schule 2"),
+    ]:
+        pb, _ = PublicBody.objects.get_or_create(
+            slug=slug,
+            defaults={
+                "name": name,
+                "email": f"info@{slug}.example.com",
+                "jurisdiction": jur,
+                "site": site,
+            },
+        )
+        pb.laws.add(law)
+
+
+def delete_kultus_school_pbs(apps, schema_editor):
+    PublicBody = apps.get_model("publicbody", "PublicBody")
+    FoiLaw = apps.get_model("publicbody", "FoiLaw")
+    Jurisdiction = apps.get_model("publicbody", "Jurisdiction")
+
+    PublicBody.objects.filter(slug__in=["kultusministerium", "schule-1", "schule-2"]).delete()
+    FoiLaw.objects.filter(slug="dsgvo").delete()
+    Jurisdiction.objects.filter(slug="edu").delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("publicbody", "0050_alter_publicbody_email"),
+        ("sites", "0002_alter_domain_unique"),
+    ]
+
+    operations = [
+        migrations.RunPython(create_kultus_school_pbs, delete_kultus_school_pbs),
+    ]

--- a/froide/settings.py
+++ b/froide/settings.py
@@ -113,6 +113,9 @@ class Base(Configuration):
 
     SITE_ID = values.IntegerValue(1)
 
+    # Allow selection of these public bodies only
+    SELECTABLE_PUBLICBODY_SLUGS = values.ListValue([])
+
     ADMINS = (
         # ('Your Name', 'your_email@example.com'),
     )


### PR DESCRIPTION
## Summary
- add DSGVO law and populate Kultusministerium and sample schools
- restrict PublicBody selection to configured slugs
- document setting in local settings example

## Testing
- `ruff check`
- `make test` *(fails: coverage command not found / git access blocked)*