### PR TITLE
Add request type dropdown in request form

### DIFF
--- a/froide/foirequest/views/make_request.py
+++ b/froide/foirequest/views/make_request.py
@@ -27,6 +27,7 @@ from froide.publicbody.serializers import PublicBodyListSerializer
 from froide.publicbody.widgets import get_widget_context
 
 from ..forms import RequestForm
+from ..forms.request import REQUEST_BODY_MAP, REQUEST_TYPE_CHOICES
 from ..models import FoiProject, FoiRequest, RequestDraft
 from ..services import CreateRequestService, SaveDraftService
 from ..utils import check_throttle
@@ -91,7 +92,7 @@ class MakeRequestView(FormView):
     def get_initial(self):
         request = self.request
         initial = {
-            "subject": request.GET.get("subject", ""),
+            "request_type": request.GET.get("request_type", ""),
             "body": request.GET.get("body", ""),
             "reference": request.GET.get("ref", ""),
             "tags": request.GET.get("tags", ""),
@@ -99,7 +100,9 @@ class MakeRequestView(FormView):
         }
         user_vars = self.get_user_template_vars()
         if user_vars:
-            initial["subject"] = replace_user_vars(initial["subject"], user_vars)
+            initial["request_type"] = replace_user_vars(
+                initial["request_type"], user_vars
+            )
             initial["body"] = replace_user_vars(initial["body"], user_vars)
 
         if "draft" in request.GET:
@@ -287,6 +290,8 @@ class MakeRequestView(FormView):
                 ],
             },
         }
+        ctx["request_type_choices"] = REQUEST_TYPE_CHOICES
+        ctx["request_body_map"] = REQUEST_BODY_MAP
         pb_ctx = get_widget_context()
         for key in pb_ctx:
             if key in ctx:

--- a/froide/tests/live/test_request.py
+++ b/froide/tests/live/test_request.py
@@ -56,8 +56,8 @@ async def test_make_not_logged_in_request(page, live_server, public_body_with_in
     await expect(buttons).to_have_count(2)
     await page.locator(".search-results .search-result .btn >> nth=0").click()
 
-    req_title = "FoiRequest Number"
-    await page.fill("[name=subject]", req_title)
+    req_title = "Korrigierte Abiturprüfung"
+    await page.locator('select[name="request_type"]').select_option(req_title)
     await page.fill("[name=body]", "Documents describing something...")
     await page.fill("[name=first_name]", "Peter")
     await page.fill("[name=last_name]", "Parker")
@@ -101,8 +101,8 @@ async def test_make_not_logged_in_request_to_public_body(page, live_server, worl
 
     user_first_name = "Peter"
     user_last_name = "Parker"
-    req_title = "FoiRequest Number"
-    await page.fill("[name=subject]", req_title)
+    req_title = "Korrigierte Abiturprüfung"
+    await page.locator('select[name="request_type"]').select_option(req_title)
     await page.fill("[name=body]", "Documents describing something...")
     await page.fill("[name=first_name]", user_first_name)
     await page.fill("[name=last_name]", user_last_name)
@@ -140,9 +140,9 @@ async def test_make_logged_in_request(
     await expect(buttons).to_have_count(2)
     await page.locator(".search-results .search-result .btn >> nth=0").click()
 
-    req_title = "FoiRequest Number"
+    req_title = "Korrigierte Abiturprüfung"
     body_text = "Documents describing & something..."
-    await page.fill("[name=subject]", req_title)
+    await page.locator('select[name="request_type"]').select_option(req_title)
     await page.fill("[name=body]", body_text)
     await page.locator("#review-button").click()
     await page.locator("#send-request-button").click()
@@ -177,9 +177,9 @@ async def test_make_logged_in_request_too_many(
     await do_login(page, live_server)
     pb = PublicBody.objects.all().first()
     await go_to_make_request_url(page, live_server, pb=pb)
-    req_title = "FoiRequest Number"
+    req_title = "Korrigierte Abiturprüfung"
     body_text = "Documents describing & something..."
-    await page.fill("[name=subject]", req_title)
+    await page.locator('select[name="request_type"]').select_option(req_title)
     await page.fill("[name=body]", body_text)
     await page.locator("#review-button").click()
     await page.locator("#send-request-button").click()
@@ -195,11 +195,11 @@ async def test_make_request_logged_out_with_existing_account(page, live_server, 
     pb = PublicBody.objects.all().first()
     user = User.objects.get(username="dummy")
     await go_to_make_request_url(page, live_server, pb=pb)
-    req_title = "FoiRequest Number"
+    req_title = "Korrigierte Abiturprüfung"
     body_text = "Documents describing & something..."
     user_first_name = user.first_name
     user_last_name = user.last_name
-    await page.fill("[name=subject]", req_title)
+    await page.locator('select[name="request_type"]').select_option(req_title)
     await page.fill("[name=body]", body_text)
     await page.fill("[name=first_name]", user_first_name)
     await page.fill("[name=last_name]", user_last_name)

--- a/frontend/javascript/components/makerequest/request-form.vue
+++ b/frontend/javascript/components/makerequest/request-form.vue
@@ -89,16 +89,16 @@
         <div class="mb-3">
           <label
             class="form-check-label"
-            for="id_subject"
-            :class="{ 'text-danger': errors.subject }">
+            for="id_request_type"
+            :class="{ 'text-danger': errors.request_type }">
             {{ i18n.subject }}
           </label>
           <div
             v-if="
-              editingDisabled && !(errors.subject && errors.subject.length > 0)
+              editingDisabled && !(errors.request_type && errors.request_type.length > 0)
             ">
-            <input type="hidden" name="subject" :value="subject" />
-            <strong>{{ subject }}</strong>
+            <input type="hidden" name="request_type" :value="request_type" />
+            <strong>{{ request_type }}</strong>
             <button
               class="btn btn-sm btn-white float-end"
               @click.prevent="editingDisabled = false">
@@ -110,25 +110,28 @@
           </div>
           <template v-else>
             <div
-              v-if="errors.subject && errors.subject.length > 0"
+              v-if="errors.request_type && errors.request_type.length > 0"
               class="alert alert-danger">
-              <p v-for="error in errors.subject" :key="error.message">
+              <p v-for="error in errors.request_type" :key="error.message">
                 {{ error.message }}
               </p>
             </div>
             <div v-if="!isMeaningfulSubject" class="alert alert-warning">
               {{ i18n.enterMeaningfulSubject }}
             </div>
-            <input
-              id="id_subject"
-              v-model="subject"
-              type="text"
-              name="subject"
-              class="form-control"
-              minlength="4"
-              :class="{ 'is-invalid': errors.subject }"
-              :placeholder="formFields.subject.placeholder"
-              @keydown.enter.prevent />
+            <select
+              id="id_request_type"
+              v-model="request_type"
+              name="request_type"
+              class="form-select"
+              :class="{ 'is-invalid': errors.request_type }">
+              <option
+                v-for="choice in formFields.request_type.choices"
+                :key="choice.value"
+                :value="choice.value">
+                {{ choice.label }}
+              </option>
+            </select>
           </template>
         </div>
       </div>
@@ -446,7 +449,7 @@ export default {
       fullTextDisabled: false,
       editingDisabled: this.hideEditing,
       fullLetter: false,
-      subjectValue: this.initialSubject || '',
+      requestTypeValue: this.initialSubject || '',
       bodyValue: this.initialBody || '',
       fullTextValue: this.initialFullText,
       firstNameValue:
@@ -513,12 +516,12 @@ export default {
     hasUser() {
       return this.user && this.user.id
     },
-    subject: {
+    request_type: {
       get() {
-        return this.subjectValue
+        return this.requestTypeValue
       },
       set(value) {
-        this.subjectValue = value
+        this.requestTypeValue = value
         this.$emit('update:initialSubject', value)
       }
     },
@@ -604,7 +607,7 @@ export default {
     },
     isMeaningfulSubject() {
       for (const re of this.nonMeaningfulSubjects) {
-        if (re.test(this.subject)) {
+        if (re.test(this.request_type)) {
           return false
         }
       }
@@ -613,6 +616,12 @@ export default {
   },
   mounted() {
     this.bodyChanged()
+    this.populateBodyFromRequestType()
+  },
+  watch: {
+    request_type() {
+      this.populateBodyFromRequestType()
+    }
   },
   methods: {
     resetFullText() {
@@ -639,6 +648,14 @@ export default {
       } else {
         this.bodyCustomErrors = []
         ta.setCustomValidity('')
+      }
+    },
+    populateBodyFromRequestType() {
+      if (
+        this.config.request_body_map &&
+        this.config.request_body_map[this.request_type]
+      ) {
+        this.body = this.config.request_body_map[this.request_type]
       }
     },
     showFullLetter() {


### PR DESCRIPTION
## Summary
- use a dropdown for choosing request type
- expose request type choices and body map to the frontend
- auto-fill the request body when type changes
- update Playwright tests for the new field

## Testing
- `pip install pytest` *(fails: Cannot connect to proxy)*