### PR TITLE
Fix migration numbering for art 15 DSGVO law

### DIFF
--- a/froide/publicbody/migrations/0052_art_15_dsgvo_law.py
+++ b/froide/publicbody/migrations/0052_art_15_dsgvo_law.py
@@ -46,7 +46,7 @@ def remove_law(apps, schema_editor):
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("publicbody", "0050_alter_publicbody_email"),
+        ("publicbody", "0051_add_kultus_school_publicbodies"),
     ]
 
     operations = [


### PR DESCRIPTION
## Summary
- rename migration file to `0052_art_15_dsgvo_law.py`
- depend on previous migration `0051_add_kultus_school_publicbodies`

## Testing
- `python manage.py migrate --plan` *(fails: ModuleNotFoundError: No module named 'configurations')*