### PR TITLE
Fix borough spelling

### DIFF
--- a/froide/settings.py
+++ b/froide/settings.py
@@ -623,7 +623,7 @@ class Base(Configuration):
             "district",
             "admin_cooperation",
             "municipality",
-            "borought",
+            "borough",
         ],
         "non_meaningful_subject_regex": [
             r"^(foi[- ])?request$",


### PR DESCRIPTION
## Summary
- fix typo in `filter_georegion_kinds` value

## Testing
- `ruff check froide/settings.py`
