### PR TITLE
Fix privacy config key

### DIFF
--- a/froide/settings.py
+++ b/froide/settings.py
@@ -572,7 +572,7 @@ class Base(Configuration):
         "doc_conversion_call_func": None,  # see settings_test for use
         "content_urls": {
             "terms": "/terms/",
-            "privary": "/privacy/",
+            "privacy": "/privacy/",
             "about": "/about/",
             "help": "/help/",
             "throttled": "/help/",


### PR DESCRIPTION
## Summary
- rename `privary` key to `privacy` in `FROIDE_CONFIG['content_urls']`

## Testing
- `ruff check`
- `make test` *(fails: coverage not installed)*