### PR TITLE
Update docs for Python 3.12 and new GIS docs

### DIFF
--- a/docs/about.rst
+++ b/docs/about.rst
@@ -44,7 +44,7 @@ History
 
 Froide was designed to mimic the functionality of `What do they know <http://whatdotheyknow.com>`_ – a Freedom of Information portal in the UK written in Ruby on Rails 2.3. At the time when a German FoI portal was needed, the general FoI solution forked from WDTK called `Alaveteli <http://alaveteli.org>`_ was hard to install and not ready for reuse.
 That's why Froide was developed in spring 2011 as a fresh start, fully
-internationalized and configurable written in Django 1.3 to power `Frag den Staat <https://fragdenstaat.de>`_ which launched in August 2011.
+internationalized and configurable, written using Django 1.3 at the time, to power `Frag den Staat <https://fragdenstaat.de>`_ which launched in August 2011.
 
 Name
 ----

--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -9,7 +9,7 @@ If you plan to setup a site based on Froide, you should not run Froide directly,
 Set up the development environment
 ----------------------------------
 
-Froide requires Python 3.5+. You should be using a Python 3 virtual environment or similar setup.
+Froide requires Python 3.12+. You should be using a Python 3 virtual environment or similar setup.
 Setup a virtual environment for development with `venv`like so::
 
     # Create virtualenv
@@ -30,7 +30,7 @@ Install the requirements inside the virtual env with `pip`::
 
 This installs the Python dependencies into the virtual environment.
 
-Froide requires one of Django's geospatial database backends. `<https://docs.djangoproject.com/en/1.11/ref/contrib/gis/install/#spatial-database>`_.
+Froide requires one of Django's geospatial database backends. `<https://docs.djangoproject.com/en/4.2/ref/contrib/gis/install/#spatial-database>`_.
 
 Froide is designed to run with the PostgreSQL database with PostGIS extension. You may be able to use a different Django-supported geospatial database, but it is not recommended. Elasticsearch is used as a search engine.
 


### PR DESCRIPTION
## Summary
- require Python 3.12+ in docs
- update the GIS link to Django 4.2 docs
- clarify historical Django version in about page

## Testing
- `make test` *(fails: coverage: No such file or directory)*