### PR TITLE
Update API docs for openapi generation

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10,3 +10,17 @@ The Froide API is available at `/api/v1/` and the interactive Froide API documen
 There are additional search endpoints for Public Bodies and FOI Requests at `/api/v1/publicbody/search/` and `/api/v1/request/search/` respectively. Use `q` as the query parameter in a GET request.
 
 GET requests do not need to be authenticated. POST, PUT and DELETE requests have to either carry a valid session cookie and a CSRF token or provide user name (you find your user name on your profile) and password via Basic Authentication.
+
+Generate schema and TypeScript client
+------------------------------------
+
+The OpenAPI schema used to describe the API can be generated along with a
+TypeScript client. Run::
+
+    make openapi
+
+This command writes the schema to ``froide/openapi-schema.yaml`` and generates
+client code in ``frontend/javascript/api/gen``. You can also run the client
+generation directly with::
+
+    pnpm run openapi


### PR DESCRIPTION
## Summary
- document the `make openapi` target
- explain how to generate the TypeScript client

## Testing
- `pnpm lint` *(fails: Connect Timeout Error)*