### PR TITLE
Add architecture overview to docs

### DIFF
--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -1,0 +1,41 @@
+Architecture
+============
+
+This document gives a high-level overview of the main components that make up a typical Froide deployment.
+
+Components
+----------
+
+* **Django backend** – provides the web application, REST API and administrative interface.
+* **Celery worker with RabbitMQ** – executes asynchronous tasks outside of the request cycle.
+* **PostgreSQL/PostGIS** – stores application data and geographic information.
+* **Elasticsearch** – powers the search features.
+* **Vue frontend** – single-page application that interacts with the backend API.
+
+Diagram
+-------
+
+The following diagram illustrates the interaction between these components:
+
+.. code-block:: text
+
+       +-------------------+
+       |    Vue frontend   |
+       +---------+---------+
+                 |
+                 v
+       +---------+---------+
+       |   Django backend  |
+       +----+---------+----+
+            |         |
+            |         v
+            |   +-----+-----+
+            |   |  Celery   |
+            |   | (RabbitMQ)|
+            |   +-----+-----+
+            |         |
+            v         v
+     +------------+  +--------------+
+     | PostgreSQL |  | Elasticsearch|
+     +------------+  +--------------+
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,7 @@ Freedom of Information Portal, but is internationalized, localized and themeable
    :maxdepth: 2
 
    about
+   architecture
    gettingstarted
    importpublicbodies
    configuration


### PR DESCRIPTION
## Summary
- document overall Froide architecture
- link new architecture page from docs index

## Testing
- `pre-commit run --files docs/index.rst docs/architecture.rst` *(fails: `pre-commit` not installed)*
- `make test` *(fails: `coverage` not found)*