### PR TITLE
Add gdal to dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
   "elasticsearch-dsl>=8.0.0,<9.0.0",
   "elasticsearch<9.0.0,>=8.0.0",
   "geoip2",
+  "gdal",
   "icalendar",
   "lxml[html-clean]>=5.2.0",
   "markdown",

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -221,6 +221,8 @@ frozenlist==1.4.1
     #   aiosignal
 geoip2==4.8.0
     # via froide (pyproject.toml)
+gdal==3.9.0
+    # via froide (pyproject.toml)
 greenlet==3.1.1
     # via
     #   froide (pyproject.toml)

--- a/requirements.txt
+++ b/requirements.txt
@@ -191,6 +191,8 @@ frozenlist==1.4.1
     #   aiosignal
 geoip2==4.8.0
     # via froide (pyproject.toml)
+gdal==3.9.0
+    # via froide (pyproject.toml)
 html5lib==1.1
     # via weasyprint
 icalendar==5.0.13


### PR DESCRIPTION
## Summary
- include gdal in project dependencies
- pin gdal in compiled requirement files

## Testing
- `make test` *(fails: coverage: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_683ad86f874c8322885c156420b9bc73