### PR TITLE
Make GDAL optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Required system tools:
 Required system libraries:
 
 - [Poppler](https://poppler.freedesktop.org)
-- [GDAL](https://gdal.org)
+- [GDAL](https://gdal.org) (optional)
 - cmake
 - pkg-config
 

--- a/froide/__init__.py
+++ b/froide/__init__.py
@@ -1,3 +1,6 @@
 from .celery import app as celery_app
+from .gis_patch import patch_gis
+
+patch_gis()
 
 __all__ = ("celery_app",)

--- a/froide/gis_patch.py
+++ b/froide/gis_patch.py
@@ -1,0 +1,80 @@
+import os
+import sys
+import types
+
+from django.db import models
+
+
+def patch_gis():
+    """Patch django.contrib.gis modules if GDAL is not used."""
+    use_gdal_env = os.environ.get("FROIDE_USE_GDAL")
+    if use_gdal_env and use_gdal_env.lower() not in {"0", "false", "no"}:
+        return False
+
+    try:
+        from django.contrib.gis.db import models as geomodels  # noqa: F401
+        return False
+    except Exception:
+        pass
+
+    fields_mod = types.ModuleType("django.contrib.gis.db.models.fields")
+
+    class GeoJSONField(models.JSONField):
+        def __init__(self, *args, geography=False, **kwargs):
+            kwargs.pop("geography", None)
+            super().__init__(*args, **kwargs)
+
+    class PointField(GeoJSONField):
+        pass
+
+    class MultiPolygonField(GeoJSONField):
+        pass
+
+    fields_mod.GeometryField = GeoJSONField
+    fields_mod.PointField = PointField
+    fields_mod.MultiPolygonField = MultiPolygonField
+
+    db_models = types.ModuleType("django.contrib.gis.db.models")
+    db_models.fields = fields_mod
+    db_models.GeometryField = GeoJSONField
+    db_models.PointField = PointField
+    db_models.MultiPolygonField = MultiPolygonField
+
+    geoip_mod = types.ModuleType("django.contrib.gis.geoip2")
+
+    def GeoIP2(*args, **kwargs):
+        raise ImportError("GeoIP2 requires GDAL")
+
+    geoip_mod.GeoIP2 = GeoIP2
+
+    geos_mod = types.ModuleType("django.contrib.gis.geos")
+
+    class Point(tuple):
+        def __new__(cls, x=0, y=0, **kwargs):
+            return tuple.__new__(cls, (x, y))
+
+    class MultiPolygon(list):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args)
+
+    geos_mod.Point = Point
+    geos_mod.MultiPolygon = MultiPolygon
+
+    admin_mod = types.ModuleType("django.contrib.gis.admin")
+    admin_mod.GISModelAdmin = type("GISModelAdmin", (), {})
+
+    gis_mod = types.ModuleType("django.contrib.gis")
+    gis_mod.db = db_models
+    gis_mod.geoip2 = geoip_mod
+    gis_mod.geos = geos_mod
+    gis_mod.admin = admin_mod
+
+    sys.modules["django.contrib.gis"] = gis_mod
+    sys.modules["django.contrib.gis.db"] = db_models
+    sys.modules["django.contrib.gis.db.models"] = db_models
+    sys.modules["django.contrib.gis.db.models.fields"] = fields_mod
+    sys.modules["django.contrib.gis.geoip2"] = geoip_mod
+    sys.modules["django.contrib.gis.geos"] = geos_mod
+    sys.modules["django.contrib.gis.admin"] = admin_mod
+
+    return True

--- a/froide/settings.py
+++ b/froide/settings.py
@@ -34,7 +34,12 @@ class Base(Configuration):
             "django.contrib.flatpages",
             "django.contrib.sitemaps",
             "django.contrib.humanize",
-            "django.contrib.gis",
+            # geodjango is optional
+            *(
+                ["django.contrib.gis"]
+                if os.environ.get("FROIDE_USE_GDAL") in {"1", "true", "True"}
+                else []
+            ),
             "channels",
             # external
             "django_elasticsearch_dsl",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ dependencies = [
   "elasticsearch-dsl>=8.0.0,<9.0.0",
   "elasticsearch<9.0.0,>=8.0.0",
   "geoip2",
-  "gdal",
   "icalendar",
   "lxml[html-clean]>=5.2.0",
   "markdown",
@@ -94,6 +93,9 @@ test = [
   "types-Markdown",
   "types-python-dateutil",
   "types-requests",
+]
+geo = [
+  "gdal",
 ]
 
 [build-system]

--- a/requirements.txt
+++ b/requirements.txt
@@ -191,8 +191,7 @@ frozenlist==1.4.1
     #   aiosignal
 geoip2==4.8.0
     # via froide (pyproject.toml)
-gdal==3.9.0
-    # via froide (pyproject.toml)
+# gdal is optional
 html5lib==1.1
     # via weasyprint
 icalendar==5.0.13


### PR DESCRIPTION
## Summary
- add a GIS patcher that provides stub GeoDjango objects when GDAL isn't used
- hook the patcher from `froide.__init__`
- make `django.contrib.gis` an optional app
- move `gdal` to optional `geo` extras
- note GDAL as optional in docs
- drop gdal from default requirements

## Testing
- `ruff check`
- `pytest -q` *(fails: unrecognized arguments '--reuse-db')*

------
https://chatgpt.com/codex/tasks/task_e_683ad982bbd08322a088e2e5fc1d5b26