### PR TITLE
Add docstrings for AccessToken manager

### DIFF
--- a/froide/accesstoken/models.py
+++ b/froide/accesstoken/models.py
@@ -7,11 +7,20 @@ from django.utils.translation import gettext_lazy as _
 
 
 class AccessTokenManager(models.Manager):
+    """Manager for :class:`AccessToken` objects.
+
+    The manager offers convenience helpers for creating and retrieving
+    user specific tokens that are used for a variety of features within
+    the application.
+    """
+
     def create_for_user(self, user, purpose):
+        """Return an existing token for ``user`` and ``purpose`` or create one."""
         at, created = AccessToken.objects.get_or_create(user=user, purpose=purpose)
         return at.token
 
     def reset(self, user, purpose):
+        """Generate a new token for ``user`` and ``purpose``."""
         new_token = uuid.uuid4()
         AccessToken.objects.filter(user=user, purpose=purpose).update(
             token=new_token, timestamp=timezone.now()
@@ -19,24 +28,28 @@ class AccessTokenManager(models.Manager):
         return new_token
 
     def get_token_by_user(self, user, purpose):
+        """Return the token for ``user`` and ``purpose`` if it exists."""
         at = self.get_by_user(user, purpose=purpose)
         if at is not None:
             return at.token
         return None
 
     def get_by_user(self, user, purpose):
+        """Return the :class:`AccessToken` for ``user`` and ``purpose``."""
         try:
             return AccessToken.objects.get(user=user, purpose=purpose)
         except AccessToken.DoesNotExist:
             return None
 
     def get_by_token(self, token, purpose):
+        """Lookup an :class:`AccessToken` by ``token`` and ``purpose``."""
         try:
             return AccessToken.objects.get(token=token, purpose=purpose)
         except AccessToken.DoesNotExist:
             return None
 
     def get_user_by_token(self, token, purpose):
+        """Return the user associated with ``token`` and ``purpose``."""
         access_token = self.get_by_token(token, purpose=purpose)
         if access_token:
             return access_token.user


### PR DESCRIPTION
## Summary
- document `AccessTokenManager` and its helpers

## Testing
- `ruff check froide/accesstoken/models.py`
- `pytest froide/accesstoken/tests.py -q` *(fails: ModuleNotFoundError: No module named 'configurations')*

------
https://chatgpt.com/codex/tasks/task_e_683b1e19e34c8322ac4819a8b38837e7